### PR TITLE
Use RRT as default.

### DIFF
--- a/config/ompl_planning.yaml
+++ b/config/ompl_planning.yaml
@@ -53,6 +53,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 right_arm:
+  default_planner_config: RRTConnectkConfigDefault 
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -68,6 +69,7 @@ right_arm:
   projection_evaluator: joints(RShoulderPitch,RShoulderRoll)
   longest_valid_segment_fraction: 0.05
 left_arm:
+  default_planner_config: RRTConnectkConfigDefault 
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -83,6 +85,7 @@ left_arm:
   projection_evaluator: joints(LShoulderPitch,LShoulderRoll)
   longest_valid_segment_fraction: 0.05
 both_arms:
+  default_planner_config: RRTConnectkConfigDefault 
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault


### PR DESCRIPTION
By default MoveIt! uses LBKPIECE that does often not return a solution.
See https://github.com/ros-planning/moveit_robots/pull/41 for more detail of the issue. And this PR follows the workaround suggested in the same aforementioned PR.